### PR TITLE
Fix missing triple quotes in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ warnings = MeteoAlarm(["estonia", "denmark"])
 
 # Print all warnings
 for warning in warnings:
-    print(f"\nWarning for {warning.area["areaDesc"]} ({warning.country}):")
-    print(f"Headline: {warning.get_headline("en-EN")}")
+    print(f"""\nWarning for {warning.area["areaDesc"]} ({warning.country}):""")
+    print(f"""Headline: {warning.get_headline("en-EN")}""")
     print(f"Severity: {warning.severity}")
     print(f"Valid until: {warning.expires}")
 ```


### PR DESCRIPTION
On Python 3.11 the code does not work with a single quoted string that contains quote delimiters for the f-string variable. Maybe it works for later versions but this would fix it for some people that want to try the most visible example.